### PR TITLE
Fix UndefinedFunctionError

### DIFF
--- a/lib/mix_templates/specs.ex
+++ b/lib/mix_templates/specs.ex
@@ -6,7 +6,7 @@ defmodule MixTemplates.Specs do
   Extra the specs (command line options that this template uses) from a
   a template and all its parents.
   """
-  def accumulate_specs(template, base_option_specs) do
+  def accumulate_specs(template, base_option_specs \\ []) do
     if parent_name = template.based_on() do
       parent_module = Cache.find_template(parent_name)
       template.options() ++ accumulate_specs(parent_module, base_option_specs)


### PR DESCRIPTION
When I tried to generate a new template project, I got this error:

```
$ mix gen template <my-project>
** (UndefinedFunctionError) function MixTemplates.Specs.accumulate_specs/1 is undefined or private. Did you mean one of:

      * accumulate_specs/2

    MixTemplates.Specs.accumulate_specs(Mix.Gen.Template.Template)
    lib/mix/tasks/gen.ex:155: Mix.Tasks.Gen.build_options/2
    lib/mix/tasks/gen.ex:137: Mix.Tasks.Gen.generate_project/4
    (mix) lib/mix/task.ex:294: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:58: Mix.CLI.run_task/2
```

It looks like this happens because of [this line](https://github.com/pragdave/mix_generator/blob/master/lib/mix/tasks/gen.ex#L155) in `mix_generator`.

You might want to do something more sophisticated than this, because `base_option_specs` might need to have some defaults.