### PR TITLE
Add copied_files option which specifies binary files to copy

### DIFF
--- a/test/templates_test.exs
+++ b/test/templates_test.exs
@@ -2,30 +2,30 @@ defmodule TemplatesTest do
   use ExUnit.Case
   alias MixTemplates,       as: MT
   alias MixTemplates.Cache
-  
+
   def load_templates(list) when is_list(list) do
     Enum.each(list, &load_templates/1)
   end
-  
+
   def load_templates(src) do
     Path.join([__DIR__, "../test_templates", src])
     |> Cache.install_from_local_tree
   end
-  
+
   describe "templates" do
-  
+
     setup do
       load_templates(["one", "two"])
       :ok
     end
-    
+
     test "are added to the cache" do
       template1 = MT.find(:one)
       assert template1.name == :one
       template2 = MT.find(:two)
-      assert template2.name == :two      
+      assert template2.name == :two
     end
-  
+
     test "know their source directory" do
       template = MT.find(:one)
       dir = template.source_dir
@@ -33,10 +33,10 @@ defmodule TemplatesTest do
       assert String.ends_with?(dir, "/template/$PROJECT_NAME$")
     end
   end
-  
+
   describe "check for existing target" do
     import MixTemplates
-  
+
     @target                Path.join(__DIR__, "_target")
     @existing_project      "project"
     @existing_project_path Path.join(@target, @existing_project)
@@ -45,7 +45,7 @@ defmodule TemplatesTest do
     @nonfile_target        Path.join(__DIR__, "_npt")
     @new_project           "new_project"
     @new_project_path      Path.join(@target, @new_project)
-    
+
     setup do
       File.mkdir!(@target)
       File.mkdir(@existing_project_path)
@@ -58,38 +58,37 @@ defmodule TemplatesTest do
         File.rmdir!(@target)
       end
     end
-  
+
     test "fails if target dir doesn't exist" do
       assert { :error, msg } = check_existence_of("nonexistent", "name")
       assert String.contains?(msg, "does not exist")
     end
-  
+
     test "fails if target exists but isn't a directory" do
       assert { :error, msg } = check_existence_of(@nonfile_target, "name")
       assert msg == "'#{@nonfile_target}' is not a directory"
     end
-  
+
     test "fails if project exists but is not a directory" do
       assert { :error, msg } = check_existence_of(@target, @existing_file)
       assert msg == "'#{@existing_file_path}' exists but is not a directory"
     end
-  
+
     test "flags an existing project" do
       assert { :maybe_update, @existing_project_path } = check_existence_of(@target, @existing_project)
     end
-  
+
     test "flags a new project" do
       assert { :need_to_create, @new_project_path } = check_existence_of(@target, @new_project)
     end
   end
-  
+
   test "merging projects not supported" do
     dummy_assigns = %{ assigns: %{}}
     assert { :error, msg } = MT.create_or_merge({:maybe_update, "a"}, "b", dummy_assigns)
     assert msg == "Updating an existing project is not yet supported"
   end
-  
-  
+
   test "can copy a file and expand the content" do
     assigns = %{ one: "number 1", two: "deux" }
     source  = "_in"
@@ -101,7 +100,74 @@ defmodule TemplatesTest do
     File.rm_rf!(dest)
     assert result == "first: number 1\nsecond: deux"
   end
-  
+
+
+  test "does not copy a binary file if copied_files is not specified" do
+    assigns = %{ one: "number 1", two: "deux" }
+    source  = "_in"
+    dest    = "_out"
+    File.write!(source, <<137>>)
+    MT.copy_and_expand(source, dest, assigns: assigns)
+    refute File.exists?("_out")
+    File.rm_rf!(source)
+    File.rm_rf!(dest)
+  end
+
+  test "copies a binary file if copied_files is :all" do
+    assigns = %{ one: "number 1", two: "deux", copied_files: :all }
+    source  = "_in"
+    dest    = "_out"
+    File.write!(source, <<137>>)
+    MT.copy_and_expand(source, dest, assigns: assigns)
+    assert File.exists?("_out")
+    File.rm_rf!(source)
+    File.rm_rf!(dest)
+  end
+
+  test "copies a binary file if copied_files is contains the file extension" do
+    assigns = %{ copied_files: %{ "png" => :all } }
+    source = "_in.png"
+    dest = "_out.png"
+    File.write!(source, <<137>>)
+    MT.copy_and_expand(source, dest, assigns: assigns)
+    assert File.exists?("_out.png")
+    File.rm_rf!(source)
+    File.rm_rf!(dest)
+  end
+
+  test "does not a copy a binary file if the file extension does not match" do
+    assigns = %{ copied_files: %{ "gif" => :all } }
+    source = "_in.png"
+    dest = "_out.png"
+    File.write!(source, <<137>>)
+    MT.copy_and_expand(source, dest, assigns: assigns)
+    refute File.exists?("_out.png")
+    File.rm_rf!(source)
+    File.rm_rf!(dest)
+  end
+
+  test "copies a binary file if the file and its extension are specified" do
+    assigns = %{ copied_files: %{ "png" => ["_in.png"] } }
+    source = "_in.png"
+    dest = "_out.png"
+    File.write!(source, <<137>>)
+    MT.copy_and_expand(source, dest, assigns: assigns)
+    assert File.exists?("_out.png")
+    File.rm_rf!(source)
+    File.rm_rf!(dest)
+  end
+
+  test "does not copy a binary file if the extension matches but the file does not" do
+    assigns = %{ copied_files: %{ "png" => ["_something_else.png"] } }
+    source = "_in.png"
+    dest = "_out.png"
+    File.write!(source, <<137>>)
+    MT.copy_and_expand(source, dest, assigns: assigns)
+    refute File.exists?("_out.png")
+    File.rm_rf!(source)
+    File.rm_rf!(dest)
+  end
+
   test "renames a target file if its name is $PROJECT_NAME$" do
     assigns = %{ one: "number 1", two: "deux", project_name: "fred" }
     source  = Path.join([__DIR__, "data/tree1/$PROJECT_NAME$"])
@@ -109,7 +175,7 @@ defmodule TemplatesTest do
     MT.copy_dir(source, dest, assigns: assigns)
     assert File.exists?("_out/lib/fred.ex")
     assert File.exists?("_out/test/fred_test.exs")
-    
+
     File.rm_rf!(dest)
    end
 end


### PR DESCRIPTION
The copied_files option allows templates to specify file formats that should not be processed with EEx, but should instead simply be copied to the new directory.

This also adds better messaging when files that are intended to be processed with EEx encounter some error. Instead of erroring and stopping the entire template generation with an ugly error, we now report that files which encounter errors are being ignored in red, and display a reason. If the reason is the file that it tried to parse with EEx was a binary file, it will inform the user to look at the `copied_files` option. That looks something like this:

<img width="744" alt="binary_file_error" src="https://user-images.githubusercontent.com/6462927/29901487-39a69d4a-8dc6-11e7-8693-5b8daa352e5f.png">

This PR tried to take into consideration discussion on https://github.com/pragdave/mix_templates/issues/6 and https://github.com/pragdave/mix_templates/pull/7

Although this PR works on its own and doesn't cause any issues, it is not possible to specify the `copied_files` option on a template without a change to https://github.com/pragdave/mix_generator to bring in the new option when generating a template. That change will be coming very soon and will be linked here.

Closes #6 