### PR TITLE
F/expose template writing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,5 +80,5 @@ Apache 2.0. See [LICENSE.md](LICENSE.md) for details.
 
 ### See also
 
-For information on writing your own templates, see the moduledoc for MixTemplate,
+For information on writing your own templates, see the moduledoc for [MixTemplates](lib/mix_templates.ex),
 also in this package.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-# Mix Template—a package for creating customized directory trees
+# Mix Template—create customized directory trees
 
+The templating package that allows you to create custom
+directory trees for your Elixir project.
 
 Manage the local installation and uninstallation of templates used
 by `mix gen`.
@@ -7,11 +9,11 @@ by `mix gen`.
 ### Install
 
     $ mix archive.install hex mix_templates
-    
+
 You probably also need to install the generator:
 
     $ mix archive.install hex mix_generator
-    
+
 
 ### Use
 
@@ -68,7 +70,7 @@ Details for each individual task can be found using `mix help template`,
 `mix help tmplate.hex` and so on.
 
 See `Mix.Tasks.Gen` (in project
-[:mix_generator](https://github.com/pragdave/mix_generator)) for details 
+[:mix_generator](https://github.com/pragdave/mix_generator)) for details
 of how to use these templates.
 
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ of how to use these templates.
 
 ### License
 
-Apache 2.0. See LICENSE.md for details.
+Apache 2.0. See [LICENSE.md](LICENSE.md) for details.
 
 ### See also
 


### PR DESCRIPTION

Three documentation change requests.  If individually you do not like any of these suggestions I can pull out those commits.

1) Title on one line... I shortened the text to make it fit on one line, can Gave It Title Case.

<img width="844" alt="screen shot 2018-05-25 at 10 08 56 am" src="https://user-images.githubusercontent.com/48086/40548862-e7ea4e78-6003-11e8-91cb-ffeeb0aa9098.png">

2) Direct link to the license

<img width="380" alt="screen shot 2018-05-25 at 10 09 08 am" src="https://user-images.githubusercontent.com/48086/40548875-f7ca7cbe-6003-11e8-92b7-800788b14a32.png">

3) Duplicated the "how to create your own template" into a markdown

This is 98% copy and pasted from the source code (only change was adding a title).  I prefer reading the fancy markup in github, but was not a huge fan of having to copy and paste the code (aka now two spots to maintain).

<img width="1044" alt="screen shot 2018-05-25 at 10 09 32 am" src="https://user-images.githubusercontent.com/48086/40548999-5000e850-6004-11e8-9670-f7241f806389.png">

If you like / appreciate these kinds of changes, my next thoughts were to clean up the hex.pm produced documentation (e.g. adding more substance to the generated docs below).

<img width="1263" alt="screen shot 2018-05-25 at 10 14 40 am" src="https://user-images.githubusercontent.com/48086/40549067-7706430a-6004-11e8-8d10-69e8883416a3.png">
